### PR TITLE
Allow generating urls without signature

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,9 +2,10 @@ package imgproxy
 
 // Config holds the parameters for constructing an imgproxy URL builder.
 type Config struct {
-	BaseURL       string
-	SignatureSize int
-	Key           string
-	Salt          string
-	EncodePath    bool
+	BaseURL           string
+	SignatureSize     int
+	Key               string
+	Salt              string
+	EncodePath        bool
+	InsecureSignature string
 }

--- a/imgproxy.go
+++ b/imgproxy.go
@@ -24,24 +24,30 @@ func NewImgproxy(cfg Config) (*Imgproxy, error) {
 		cfg.BaseURL = cfg.BaseURL + "/"
 	}
 
-	if cfg.SignatureSize < 1 || cfg.SignatureSize > 32 {
-		return nil, errors.WithStack(ErrInvalidSignature)
-	}
+	if cfg.Key != "" && cfg.Salt != "" {
+		if cfg.SignatureSize < 1 || cfg.SignatureSize > 32 {
+			return nil, errors.WithStack(ErrInvalidSignature)
+		}
 
-	key, err := hex.DecodeString(cfg.Key)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
+		key, err := hex.DecodeString(cfg.Key)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
 
-	salt, err := hex.DecodeString(cfg.Salt)
-	if err != nil {
-		return nil, errors.WithStack(err)
+		salt, err := hex.DecodeString(cfg.Salt)
+		if err != nil {
+			return nil, errors.WithStack(err)
+		}
+
+		return &Imgproxy{
+			cfg:  cfg,
+			salt: salt,
+			key:  key,
+		}, nil
 	}
 
 	return &Imgproxy{
-		cfg:  cfg,
-		salt: salt,
-		key:  key,
+		cfg: cfg,
 	}, nil
 }
 

--- a/imgproxy_test.go
+++ b/imgproxy_test.go
@@ -23,6 +23,17 @@ func Test_NewImgproxy(t *testing.T) {
 	})
 }
 
+func Test_NewImgproxyWithoutKey(t *testing.T) {
+	Convey("NewImgproxy()", t, func() {
+		Convey("Retunrs error if the signature is not valid", func() {
+			_, err := NewImgproxy(Config{
+				BaseURL: "http://localhost",
+			})
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 func Test_ImgproxyBuilder(t *testing.T) {
 	Convey("Imgproxy.Builder()", t, func() {
 		Convey("Returns the url with the uri encoded and sign when Encode is true and key and salt are not empty", func() {
@@ -53,6 +64,22 @@ func Test_ImgproxyBuilder(t *testing.T) {
 			url, err := ip.Builder().Generate("my/image.jpg")
 			So(err, ShouldBeNil)
 			So(url, ShouldEqual, "http://localhost/insecure/plain/my/image.jpg")
+		})
+
+		Convey("Returns the url with custom insecure signature when key and salt are empty", func() {
+			ip, err := NewImgproxy(Config{
+				BaseURL:           "http://localhost",
+				SignatureSize:     15,
+				Key:               "",
+				Salt:              "",
+				EncodePath:        false,
+				InsecureSignature: "XXX",
+			})
+			So(err, ShouldBeNil)
+
+			url, err := ip.Builder().Generate("my/image.jpg")
+			So(err, ShouldBeNil)
+			So(url, ShouldEqual, "http://localhost/XXX/plain/my/image.jpg")
 		})
 
 		Convey("With key salt and no encoded", func() {

--- a/url.go
+++ b/url.go
@@ -44,6 +44,11 @@ func (i *ImgproxyURLData) Generate(uri string) (string, error) {
 	uriWithOptions := options + uri
 
 	if len(i.salt) == 0 && len(i.key) == 0 {
+		insecureSignature := i.cfg.InsecureSignature
+		if insecureSignature == "" {
+			insecureSignature = "insecure"
+		}
+
 		return i.cfg.BaseURL + insecureSignature + uriWithOptions, nil
 	}
 


### PR DESCRIPTION
The Generate function already allowed it, but the `NewImgproxy` method did not.