### PR TITLE
Use correct parameter types

### DIFF
--- a/imgproxy_test.go
+++ b/imgproxy_test.go
@@ -134,11 +134,11 @@ func Test_ImgproxyBuilder(t *testing.T) {
 
 				Convey("Higher than zero sets the option", func() {
 					url, err := ip.Builder().
-						DPR(10).
+						DPR(2.123).
 						Generate("my/image.jpg")
 
 					So(err, ShouldBeNil)
-					So(url, ShouldEqual, "http://localhost/H3-NasL_V_EQt3f84ocr/dpr:10/plain/my/image.jpg")
+					So(url, ShouldEqual, "http://localhost/8egu927RcXe616QvIBRA/dpr:2.123/plain/my/image.jpg")
 				})
 			})
 
@@ -242,18 +242,18 @@ func Test_ImgproxyBuilder(t *testing.T) {
 				Convey("With offset sets the option", func() {
 					url, err := ip.Builder().
 						Watermark(
-							1,
+							0.123,
 							WatermarkPositionWest,
 							&WatermarkOffset{
-								X: 1,
-								Y: 2,
+								X: 1.2,
+								Y: 2.4,
 							},
 							3,
 						).
 						Generate("my/image.jpg")
 
 					So(err, ShouldBeNil)
-					So(url, ShouldEqual, "http://localhost/2DBmLVDEF_HSDTlksj1c/wm:1:we:1:2:3/plain/my/image.jpg")
+					So(url, ShouldEqual, "http://localhost/v-DxulpAqvDlwH6y0C2s/wm:0.123:we:1.2:2.4:3/plain/my/image.jpg")
 				})
 
 				Convey("Without offset sets the option", func() {

--- a/imgproxy_test.go
+++ b/imgproxy_test.go
@@ -142,13 +142,24 @@ func Test_ImgproxyBuilder(t *testing.T) {
 				})
 			})
 
-			Convey("Enlarge sets enlarge option", func() {
-				url, err := ip.Builder().
-					Enlarge(1).
-					Generate("my/image.jpg")
+			Convey("Enlarge", func() {
+				Convey("With true sets it to 1", func() {
+					url, err := ip.Builder().
+						Enlarge(true).
+						Generate("my/image.jpg")
 
-				So(err, ShouldBeNil)
-				So(url, ShouldEqual, "http://localhost/Kh3OA5md8aQEj5l9oc4t/el:1/plain/my/image.jpg")
+					So(err, ShouldBeNil)
+					So(url, ShouldEqual, "http://localhost/Kh3OA5md8aQEj5l9oc4t/el:1/plain/my/image.jpg")
+				})
+
+				Convey("With false sets it to 0", func() {
+					url, err := ip.Builder().
+						Enlarge(false).
+						Generate("my/image.jpg")
+
+					So(err, ShouldBeNil)
+					So(url, ShouldEqual, "http://localhost/P2bzObD8GValdJ8EuqzP/el:0/plain/my/image.jpg")
+				})
 			})
 
 			Convey("Gravity", func() {

--- a/imgproxy_test.go
+++ b/imgproxy_test.go
@@ -101,7 +101,7 @@ func Test_ImgproxyBuilder(t *testing.T) {
 					Generate("my/image.jpg")
 
 				So(err, ShouldBeNil)
-				So(url, ShouldEqual, "http://localhost/YohdbDjMgBhATlRO7Ifs/rs:fill/plain/my/image.jpg")
+				So(url, ShouldEqual, "http://localhost/7xBbA_IVAkCFtuWng6tp/rt:fill/plain/my/image.jpg")
 			})
 
 			Convey("Width sets width option", func() {

--- a/url.go
+++ b/url.go
@@ -141,8 +141,8 @@ func (i *ImgproxyURLData) DPR(dpr float64) *ImgproxyURLData {
 }
 
 // Enlarge enlarges the image.
-func (i *ImgproxyURLData) Enlarge(enlarge int) *ImgproxyURLData {
-	return i.SetOption("el", strconv.Itoa(enlarge))
+func (i *ImgproxyURLData) Enlarge(enlarge bool) *ImgproxyURLData {
+	return i.SetOption("el", boolAsNumberString(enlarge))
 
 }
 

--- a/url.go
+++ b/url.go
@@ -114,7 +114,7 @@ func (i *ImgproxyURLData) Size(width int, height int, enlarge bool) *ImgproxyURL
 
 // ResizingType sets the resizing type.
 func (i *ImgproxyURLData) ResizingType(resizingType ResizingType) *ImgproxyURLData {
-	return i.SetOption("rs", string(resizingType))
+	return i.SetOption("rt", string(resizingType))
 }
 
 // Width defines the width of the resulting image.

--- a/url.go
+++ b/url.go
@@ -132,9 +132,9 @@ func (i *ImgproxyURLData) Height(height int) *ImgproxyURLData {
 }
 
 // DPR controls the output density of your image.
-func (i *ImgproxyURLData) DPR(dpr int) *ImgproxyURLData {
+func (i *ImgproxyURLData) DPR(dpr float64) *ImgproxyURLData {
 	if dpr > 0 {
-		return i.SetOption("dpr", strconv.Itoa(dpr))
+		return i.SetOption("dpr", formatFloat(dpr))
 	}
 
 	return i
@@ -316,21 +316,21 @@ const (
 
 // WatermarkOffset holds the watermark coordinates.
 type WatermarkOffset struct {
-	X int
-	Y int
+	X float64
+	Y float64
 }
 
 // Watermark places a watermark on the processed image.
-func (i *ImgproxyURLData) Watermark(opacity int, position WatermarkPosition, offset *WatermarkOffset, scale int) *ImgproxyURLData {
+func (i *ImgproxyURLData) Watermark(opacity float64, position WatermarkPosition, offset *WatermarkOffset, scale float64) *ImgproxyURLData {
 	var offsetStr string
 
 	if offset != nil {
-		offsetStr = fmt.Sprintf(":%d:%d", offset.X, offset.Y)
+		offsetStr = fmt.Sprintf(":%s:%s", formatFloat(offset.X), formatFloat(offset.Y))
 	}
 
 	return i.SetOption("wm",
 		fmt.Sprintf(
-			"%d:%s%s:%d", opacity, position, offsetStr, scale,
+			"%s:%s%s:%s", formatFloat(opacity), position, offsetStr, formatFloat(scale),
 		),
 	)
 }

--- a/util.go
+++ b/util.go
@@ -1,9 +1,15 @@
 package imgproxy
 
+import "strconv"
+
 func boolAsNumberString(i bool) string {
 	if i {
 		return "1"
 	}
 
 	return "0"
+}
+
+func formatFloat(f float64) string {
+	return strconv.FormatFloat(f, 'f', -1, 64)
 }

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,30 @@
+package imgproxy
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func Test_boolAsNumberString(t *testing.T) {
+	Convey("boolAsNumberString()", t, func() {
+		Convey("Returns 1 for true", func() {
+			So(boolAsNumberString(true), ShouldEqual, "1")
+		})
+		Convey("Returns 0 for false", func() {
+			So(boolAsNumberString(false), ShouldEqual, "0")
+		})
+	})
+}
+
+func Test_formatFloat(t *testing.T) {
+	Convey("formatFloat()", t, func() {
+		Convey("Returns the float as string without trailing zeros", func() {
+			So(formatFloat(1.234000), ShouldEqual, "1.234")
+		})
+
+		Convey("Returns the float without decimals", func() {
+			So(formatFloat(2), ShouldEqual, "2")
+		})
+	})
+}


### PR DESCRIPTION
Some methods did accept only integers, whereas imgproxy allows floats for the option.

This changes method arguments, so is a breaking change.